### PR TITLE
Feature: wire Logging into AppCore and support throwing container factories

### DIFF
--- a/Packages/AppCore/Package.swift
+++ b/Packages/AppCore/Package.swift
@@ -13,12 +13,14 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../../Features/Resume"),
+        .package(path: "../../Platform/Logging")
     ],
     targets: [
         .target(
             name: "AppCore",
             dependencies: [
                 .product(name: "Resume", package: "Resume"),
+                .product(name: "Logging", package: "Logging")
             ]
         ),
         .testTarget(

--- a/Packages/AppCore/Package.swift
+++ b/Packages/AppCore/Package.swift
@@ -13,14 +13,14 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../../Features/Resume"),
-        .package(path: "../../Platform/Logging")
+        .package(path: "../../Platform/Logging"),
     ],
     targets: [
         .target(
             name: "AppCore",
             dependencies: [
                 .product(name: "Resume", package: "Resume"),
-                .product(name: "Logging", package: "Logging")
+                .product(name: "Logging", package: "Logging"),
             ]
         ),
         .testTarget(

--- a/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
+++ b/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
@@ -16,20 +16,26 @@ public class CompositionRoot {
     private let environment: Environment
     private let registry: FeatureRegistry
 
-    private(set) lazy var container: Container = {
-        let container = Container()
-
-        container.register(Environment.self) { _ in
-            self.environment
-        }
-
-        registry.registerAll(in: container)
-        return container
-    }()
+    private(set) lazy var container: Container  = makeContainer()
 
     public init(environment: Environment, registry: FeatureRegistry) {
         self.environment = environment
         self.registry = registry
+    }
+
+    private func makeContainer() -> Container {
+        let container = Container()
+        do {
+            try container.register(Environment.self) { _ in
+                self.environment
+            }
+
+            try registry.registerAll(in: container)
+            return container
+
+        } catch {
+            fatalError("Failed to build continer")
+        }
     }
 
     @MainActor

--- a/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
+++ b/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
@@ -16,7 +16,7 @@ public class CompositionRoot {
     private let environment: Environment
     private let registry: FeatureRegistry
 
-    private(set) lazy var container: Container  = makeContainer()
+    private(set) lazy var container: Container = makeContainer()
 
     public init(environment: Environment, registry: FeatureRegistry) {
         self.environment = environment

--- a/Packages/AppCore/Sources/AppCore/Container.swift
+++ b/Packages/AppCore/Sources/AppCore/Container.swift
@@ -12,9 +12,9 @@ public final class Container {
 
     public init() {}
 
-    func register<T>(_ type: T.Type, factory: @escaping (Container) -> T) {
+    func register<T>(_ type: T.Type, factory: @escaping (Container) throws -> T) throws {
         factories[ObjectIdentifier(type)] = { container in
-            factory(container)
+            try factory(container)
         }
     }
 
@@ -23,7 +23,7 @@ public final class Container {
             throw ResolutionError.missingRegistration
         }
 
-        guard let resolved = factory(self) as? T else {
+        guard let resolved = try factory(self) as? T else {
             throw ResolutionError.typeMismatch
         }
 

--- a/Packages/AppCore/Sources/AppCore/Container.swift
+++ b/Packages/AppCore/Sources/AppCore/Container.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public final class Container {
-    private var factories: [ObjectIdentifier: (Container) -> Any] = [:]
+    private var factories: [ObjectIdentifier: (Container) throws -> Any] = [:]
 
     public init() {}
 

--- a/Packages/AppCore/Sources/AppCore/DependencyRegistering.swift
+++ b/Packages/AppCore/Sources/AppCore/DependencyRegistering.swift
@@ -7,5 +7,5 @@
 
 public protocol DependencyRegistering {
     @MainActor
-    static func register(in container: Container)
+    static func register(in container: Container) throws
 }

--- a/Packages/AppCore/Sources/AppCore/FeatureRegistry.swift
+++ b/Packages/AppCore/Sources/AppCore/FeatureRegistry.swift
@@ -13,9 +13,9 @@ public struct FeatureRegistry {
     }
 
     @MainActor
-    public func registerAll(in container: Container) {
+    public func registerAll(in container: Container) throws {
         for registrant in registrants {
-            registrant.register(in: container)
+            try registrant.register(in: container)
         }
     }
 }

--- a/Packages/AppCore/Sources/AppCore/ResumeRegister.swift
+++ b/Packages/AppCore/Sources/AppCore/ResumeRegister.swift
@@ -11,8 +11,8 @@ import Resume
 @available(iOS 13.0, *)
 public enum ResumeRegister: DependencyRegistering {
     @MainActor
-    public static func register(in container: Container) {
-        container.register(ResumeFeatureProviding.self) { _ in
+    public static func register(in container: Container) throws {
+        try container.register(ResumeFeatureProviding.self) { _ in
             ResumeFeature()
         }
     }

--- a/Packages/AppCore/Tests/AppCoreTests/ContainerTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/ContainerTests.swift
@@ -60,14 +60,13 @@ struct AppContainerTests {
 
         // Act
         try sut.register(InMemoryLogSink.self) { _ in
-           sink
+            sink
         }
 
         try sut.register(Logger.self) { resolver in
             let resolvedSink = try resolver.resolve(InMemoryLogSink.self)
             return DefaultLogger(sinks: [resolvedSink])
         }
-
 
         let logger = try sut.resolve(Logger.self)
         let resolvedSink = try sut.resolve(InMemoryLogSink.self)

--- a/Packages/AppCore/Tests/AppCoreTests/ContainerTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/ContainerTests.swift
@@ -14,7 +14,7 @@ struct AppContainerTests {
     @Test("resolve returns an instance registered for the requested type")
     func registerAndResolve() throws {
         let container = Container()
-        container.register(ServiceA.self) { _ in ServiceA(id: 1) }
+        try container.register(ServiceA.self) { _ in ServiceA(id: 1) }
 
         _ = try container.resolve(ServiceA.self)
     }
@@ -31,8 +31,8 @@ struct AppContainerTests {
     @Test("register replaces an existing factory for the same type")
     func registerOverridesExistingFactory() throws {
         let container = Container()
-        container.register(ServiceA.self) { _ in ServiceA(id: 1) }
-        container.register(ServiceA.self) { _ in ServiceA(id: 2) }
+        try container.register(ServiceA.self) { _ in ServiceA(id: 1) }
+        try container.register(ServiceA.self) { _ in ServiceA(id: 2) }
 
         let service = try container.resolve(ServiceA.self)
 
@@ -42,13 +42,40 @@ struct AppContainerTests {
     @Test("a factory can resolve other dependencies from the container")
     func factoryResolveOtherDependencies() throws {
         let container = Container()
-        container.register(ServiceA.self) { _ in ServiceA(id: 1) }
-        container.register(ServiceB.self) { container in
+        try container.register(ServiceA.self) { _ in ServiceA(id: 1) }
+        try container.register(ServiceB.self) { container in
             let service: ServiceA = try! container.resolve(ServiceA.self)
             return ServiceB(service: service)
         }
 
         _ = try container.resolve(ServiceB.self)
+    }
+
+    @Test("container wires logger to the configured in memory sink")
+    func containerWiresLoggerToConfiguredInMemorySink() throws {
+        // Arrange
+        let sut = Container()
+        let sink = InMemoryLogSink()
+
+        // Act
+        try sut.register(InMemoryLogSink.self) { _ in
+           sink
+        }
+
+        try sut.register(Logger.self) { resolver in
+            let resolvedSink = try resolver.resolve(InMemoryLogSink.self)
+            return DefaultLogger(sinks: [resolvedSink])
+        }
+
+
+        let logger = try sut.resolve(Logger.self)
+        let resolvedSink = try sut.resolve(InMemoryLogSink.self)
+
+        logger.log(LogEntry(message: "Logged"))
+
+        // Assert
+        #expect(resolvedSink.entries.count == 1)
+        #expect(resolvedSink.entries.first?.message == "Logged")
     }
 }
 
@@ -58,7 +85,7 @@ struct DependencyRegisteringTests {
     func registrantCanRegisterDependencies() throws {
         let container = Container()
 
-        FeatureA.register(in: container)
+        try FeatureA.register(in: container)
 
         _ = try container.resolve(ServiceA.self)
     }
@@ -70,7 +97,7 @@ struct FeatureRegistryTests {
     func registerAllCallsEachRegistrant() throws {
         let container = Container()
 
-        FeatureRegistry(registrants: [FeatureA.self, FeatureB.self])
+        try FeatureRegistry(registrants: [FeatureA.self, FeatureB.self])
             .registerAll(in: container)
 
         _ = try container.resolve(ServiceA.self)
@@ -79,14 +106,14 @@ struct FeatureRegistryTests {
 }
 
 enum FeatureA: DependencyRegistering {
-    static func register(in container: Container) {
-        container.register(ServiceA.self) { _ in ServiceA(id: 1) }
+    static func register(in container: Container) throws {
+        try container.register(ServiceA.self) { _ in ServiceA(id: 1) }
     }
 }
 
 enum FeatureB: DependencyRegistering {
-    static func register(in container: Container) {
-        container.register(ServiceB.self) { container in
+    static func register(in container: Container) throws {
+        try container.register(ServiceB.self) { container in
             let dep: ServiceA = try! container.resolve(ServiceA.self)
             return ServiceB(service: dep)
         }

--- a/Packages/AppCore/Tests/AppCoreTests/ContainerTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/ContainerTests.swift
@@ -7,6 +7,7 @@
 //
 
 @testable import AppCore
+import Logging
 import Testing
 
 @MainActor

--- a/Packages/AppCore/Tests/AppCoreTests/ResumeRegisterTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/ResumeRegisterTests.swift
@@ -16,7 +16,7 @@ struct ResumeRegisterTests {
         // Arrange
         let container = Container()
 
-        ResumeRegister.register(in: container)
+        try ResumeRegister.register(in: container)
 
         #expect(throws: Never.self) {
             _ = try container.resolve(ResumeFeatureProviding.self)

--- a/Packages/Platform/Logging/Sources/Logging/DefaultLogger.swift
+++ b/Packages/Platform/Logging/Sources/Logging/DefaultLogger.swift
@@ -5,14 +5,14 @@
 //  Created by Ives Murillo on 3/16/26.
 //
 
-final class DefaultLogger: Logger {
+public final class DefaultLogger: Logger {
     private let sinks: [any LogSink]
 
-    init(sinks: [any LogSink]) {
+    public init(sinks: [any LogSink]) {
         self.sinks = sinks
     }
 
-    func log(_ entry: LogEntry) {
+    public func log(_ entry: LogEntry) {
         for sink in sinks {
             sink.write(entry)
         }

--- a/Packages/Platform/Logging/Sources/Logging/InMemoryLogSink.swift
+++ b/Packages/Platform/Logging/Sources/Logging/InMemoryLogSink.swift
@@ -5,10 +5,12 @@
 //  Created by Ives Murillo on 3/16/26.
 //
 
-final class InMemoryLogSink: LogSink {
-    private(set) var entries: [LogEntry] = []
+public final class InMemoryLogSink: LogSink {
+    public private(set) var entries: [LogEntry] = []
 
-    func write(_ entry: LogEntry) {
+    public init() {}
+
+    public func write(_ entry: LogEntry) {
         entries.append(entry)
     }
 }

--- a/Packages/Platform/Logging/Sources/Logging/LogEntry.swift
+++ b/Packages/Platform/Logging/Sources/Logging/LogEntry.swift
@@ -5,6 +5,10 @@
 //  Created by Ives Murillo on 3/16/26.
 //
 
-struct LogEntry {
-    let message: String
+public struct LogEntry {
+    public let message: String
+
+    public init(message: String) {
+        self.message = message
+    }
 }

--- a/Packages/Platform/Logging/Sources/Logging/Logger.swift
+++ b/Packages/Platform/Logging/Sources/Logging/Logger.swift
@@ -5,10 +5,10 @@
 //  Created by Ives Murillo on 3/16/26.
 //
 
-protocol LogSink {
+public protocol LogSink {
     func write(_ entry: LogEntry)
 }
 
-protocol Logger {
+public protocol Logger {
     func log(_ entry: LogEntry)
 }

--- a/Packages/Platform/Logging/Tests/LoggingTests/LoggingTests.swift
+++ b/Packages/Platform/Logging/Tests/LoggingTests/LoggingTests.swift
@@ -8,7 +8,27 @@
 @testable import Logging
 import Testing
 
-@Suite()
+@Suite("Loggin feature Integration tests")
 struct LoggingTests {
-    @Test func logging() {}
+    @Test("logger can be injected into a client")
+    func loggerCanBeInjectedIntoClient() {
+        // Arrange
+        let sink = InMemoryLogSink()
+        let logger = DefaultLogger(sinks: [sink])
+        let client = LoggerClient(logger: logger)
+        // Act
+        client.doWork()
+
+        // Assert
+        #expect(sink.entries.count == 1)
+        #expect(sink.entries[0].message == "Client log")
+
+    }
+}
+
+struct LoggerClient {
+    let logger: any Logger
+    func doWork() {
+        logger.log(.init(message: "Client log"))
+    }
 }

--- a/Packages/Platform/Logging/Tests/LoggingTests/LoggingTests.swift
+++ b/Packages/Platform/Logging/Tests/LoggingTests/LoggingTests.swift
@@ -22,7 +22,6 @@ struct LoggingTests {
         // Assert
         #expect(sink.entries.count == 1)
         #expect(sink.entries[0].message == "Client log")
-
     }
 }
 


### PR DESCRIPTION
## Summary
Wire the minimal `Logging` capability into `AppCore` and refactor the DI container to support throwing factory closures.

This PR establishes the first app-level logging wiring path and updates the container so dependency factories can safely resolve other dependencies using `try`.

## Why
Logging is being introduced as a foundational platform capability for MySkillo. To wire it through app composition correctly, the container must allow dependency factories to fail when nested resolution fails.

Without this refactor, container registrations could not safely compose dependencies such as building a `Logger` from a resolved sink.

This change keeps the logging integration minimal while improving the correctness of the dependency system.

## Changes
- Wired the minimal logging pipeline into `AppCore`
- Added app-level logging wiring coverage
- Refactored `Container` to store throwing factory closures
- Updated `register` factory signature to support throwing dependency creation
- Updated `resolve` to execute throwing factories safely
- Updated affected registrations and tests to use the new throwing container behavior
- Verified logger wiring through a configured `InMemoryLogSink`

## Testing
- [x] Existing tests updated for throwing container factories
- [x] Logging wiring test added in `AppCore`
- [x] Unit tests pass locally
- [x] Project builds successfully

## Notes
This PR keeps logging integration intentionally small:
- no console sink yet
- no formatting yet
- no metadata yet
- no source location yet
- no filtering yet

The goal of this change is to prove the first minimal wiring path:

`AppCore composition → Logger → InMemoryLogSink`

Future PRs can build on this foundation by wiring logging into more app components and expanding the logging model incrementally.