### PR TITLE
Refactor: Fix SwiftFormat lint violations

### DIFF
--- a/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
+++ b/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
@@ -65,7 +65,7 @@ import UIKit
 public class CompositionRoot {
     /// The application environment configuration (e.g., production, development).
     private let environment: Environment
-    
+
     /// The registry containing all feature module dependency registrants.
     private let registry: FeatureRegistry
 
@@ -148,4 +148,3 @@ public class CompositionRoot {
         }
     }
 }
-

--- a/Packages/AppCore/Sources/AppCore/Container.swift
+++ b/Packages/AppCore/Sources/AppCore/Container.swift
@@ -28,7 +28,7 @@ import Foundation
 /// - Note: `Container` is not thread-safe. All registrations and resolutions should
 ///   occur on the same thread, typically the main thread via `@MainActor`.
 public final class Container {
-    private var factories: [ObjectIdentifier : (Container) throws -> Any] = [:]
+    private var factories: [ObjectIdentifier: (Container) throws -> Any] = [:]
 
     public init() {}
 

--- a/Packages/Platform/PlatformContracts/Tests/PlatformContractsTests/LoggingTests.swift
+++ b/Packages/Platform/PlatformContracts/Tests/PlatformContractsTests/LoggingTests.swift
@@ -5,12 +5,11 @@
 //  Created by Ives Murillo on 3/17/26.
 //
 
-import Testing
 @testable import PlatformContracts
+import Testing
 
 @Suite("Logging contract tests")
 struct LoggingTests {
-
     @Test("log can be called from protocol")
     func logCanBeCalledFromProtocol() {
         // Arrange
@@ -23,7 +22,5 @@ struct LoggingTests {
 }
 
 struct LoggerSpy: Logging {
-    func log(_ string: String) {
-
-    }
+    func log(_: String) {}
 }

--- a/Packages/Platform/PlatformContracts/Tests/PlatformContractsTests/PlatformContractsTests.swift
+++ b/Packages/Platform/PlatformContracts/Tests/PlatformContractsTests/PlatformContractsTests.swift
@@ -1,4 +1,4 @@
-import Testing
 @testable import PlatformContracts
+import Testing
 
 @Test func example() {}


### PR DESCRIPTION
## Summary
Fixes all SwiftFormat lint violations flagged by the CI `swiftformat . --lint` check across 4 files.

## Why
The CI pipeline was failing with exit code 1 due to SwiftFormat lint errors. These must pass before any merge to main.

## Changes
- Updated `Container.swift` — removed extra space before `:` in dictionary type declaration (`spaceAroundOperators`)
- Updated `PlatformContractsTests.swift` — sorted imports alphabetically (`sortImports`)
- Updated `LoggingTests.swift` — sorted imports, removed leading blank line in struct scope, marked unused parameter with `_`, collapsed empty function body (`sortImports`, `blankLinesAtStartOfScope`, `unusedArguments`, `emptyBraces`, `blankLinesAtEndOfScope`)
- Updated `CompositionRoot.swift` — removed trailing space, removed extra blank line at end of file (`trailingSpace`, `consecutiveBlankLines`)

## Testing
- [ ] Unit tests pass
- [ ] App builds successfully
- [ ] Verified manually in simulator

## Notes
No logic changes — formatting only. Run `swiftformat . --lint` to confirm exit code 0.