### PR TITLE
Docs: Add DocC documentation to PlatformContracts Logging protocol

### DIFF
--- a/Packages/Platform/PlatformContracts/Sources/PlatformContracts/Logging.swift
+++ b/Packages/Platform/PlatformContracts/Sources/PlatformContracts/Logging.swift
@@ -5,6 +5,62 @@
 //  Created by Ives Murillo on 3/17/26.
 //
 
+/// A platform-level abstraction for logging.
+///
+/// `Logging` is the shared contract that all feature modules should depend on
+/// when they need to emit log messages. It intentionally keeps a minimal surface
+/// area — a single `log(_:)` method — so features stay decoupled from any
+/// concrete logging implementation (e.g. `DefaultLogger` from the `Logging` package).
+///
+/// ## Dependency inversion
+///
+/// Feature modules import `PlatformContracts` and declare a dependency on `any Logging`.
+/// The composition root (`AppCore`) resolves and injects the concrete implementation.
+/// This means a feature never needs to know *how* messages are written — only *that*
+/// it can write them.
+///
+/// ## Usage
+///
+/// ### In a feature module
+///
+/// ```swift
+/// import PlatformContracts
+///
+/// struct MyFeature {
+///     private let logger: any Logging
+///
+///     init(logger: any Logging) {
+///         self.logger = logger
+///     }
+///
+///     func doSomething() {
+///         logger.log("MyFeature: doSomething called")
+///     }
+/// }
+/// ```
+///
+/// ### Providing a concrete implementation (composition root)
+///
+/// ```swift
+/// try container.register(Logging.self) { _ in
+///     DefaultLogger()
+/// }
+/// ```
+///
+/// ### In tests (using a spy)
+///
+/// ```swift
+/// struct LoggerSpy: Logging {
+///     var messages: [String] = []
+///     mutating func log(_ string: String) { messages.append(string) }
+/// }
+/// ```
+///
+/// - Note: Conform concrete loggers to this protocol inside `AppCore` or a dedicated
+///   adapter — never inside the feature module itself.
 public protocol Logging {
+    /// Emits a log message.
+    ///
+    /// - Parameter string: The human-readable message to log.
     func log(_ string: String)
 }


### PR DESCRIPTION
## Summary
Adds DocC documentation to the `Logging` protocol in `PlatformContracts`, clarifying its role as a platform-level abstraction and how it should be used across the codebase.

## Why
The `Logging` protocol existed without any documentation, making it unclear why it lives in `PlatformContracts` separately from the `Logging` package, and how feature modules should consume it. This caused confusion about the intended dependency inversion pattern.

## Changes
- Updated `PlatformContracts/Sources/PlatformContracts/Logging.swift` — added full DocC documentation to the `Logging` protocol and its `log(_:)` method, including usage examples for feature modules, the composition root, and test spies

## Testing
- [ ] Unit tests pass
- [ ] App builds successfully
- [ ] Verified manually in simulator

## Notes
No logic changes — documentation only. A follow-up issue should wire `PlatformContracts` as a dependency in feature modules and conform `DefaultLogger` (from the `Logging` package) to `PlatformContracts.Logging` inside `AppCore`.