### PR TITLE
 Docs: Add DocC documentation to the Logging package

### DIFF
--- a/Packages/Platform/Logging/Sources/Logging/DefaultLogger.swift
+++ b/Packages/Platform/Logging/Sources/Logging/DefaultLogger.swift
@@ -5,13 +5,73 @@
 //  Created by Ives Murillo on 3/16/26.
 //
 
+/// The default concrete implementation of ``Logger``.
+///
+/// `DefaultLogger` is the orchestrator of the logging pipeline. It holds a
+/// list of ``LogSink`` destinations and forwards every ``LogEntry`` it receives
+/// to each of them in order.
+///
+/// ## Design: composition over inheritance
+///
+/// `DefaultLogger` does not decide *where* logs go — that responsibility
+/// belongs to the sinks injected at creation time. This is the
+/// **Strategy pattern**: the behavior (output destination) is swapped in from
+/// the outside rather than hard-coded. Adding a new output (e.g. a file sink,
+/// a remote sink) requires zero changes to `DefaultLogger`.
+///
+/// ## Usage
+///
+/// ```swift
+/// // Production: console + remote
+/// let logger = DefaultLogger(sinks: [ConsoleSink(), RemoteSink()])
+///
+/// // Tests: capture output in memory
+/// let sink = InMemoryLogSink()
+/// let logger = DefaultLogger(sinks: [sink])
+/// logger.log(LogEntry(message: "hello"))
+/// assert(sink.entries.count == 1)
+/// ```
+///
+/// ## Why `final`?
+///
+/// Marking the class `final` signals that `DefaultLogger` is not designed to
+/// be subclassed. Behavior should be extended by composing sinks, not by
+/// inheriting and overriding. `final` also allows the compiler to use static
+/// dispatch for method calls, which is a small but real performance win.
+///
+/// ## Wiring to `PlatformContracts.Logging`
+///
+/// Feature modules depend on the thin `PlatformContracts.Logging` contract
+/// (`func log(_ string: String)`), not on `DefaultLogger` directly. `AppCore`
+/// bridges the two with a conformance extension:
+///
+/// ```swift
+/// extension DefaultLogger: PlatformContracts.Logging {
+///     public func log(_ string: String) {
+///         log(LogEntry(message: string))
+///     }
+/// }
+/// ```
+///
+/// - SeeAlso: ``Logger``, ``LogSink``, ``LogEntry``, ``InMemoryLogSink``
 public final class DefaultLogger: Logger {
     private let sinks: [any LogSink]
 
+    /// Creates a logger that dispatches entries to the given sinks.
+    ///
+    /// Pass an empty array to create a no-op logger that silently discards
+    /// all entries — useful in previews or placeholder contexts.
+    ///
+    /// - Parameter sinks: The output destinations that will receive each
+    ///   ``LogEntry``. Entries are forwarded in the order sinks appear in
+    ///   this array.
     public init(sinks: [any LogSink]) {
         self.sinks = sinks
     }
 
+    /// Forwards the entry to every configured sink in order.
+    ///
+    /// - Parameter entry: The log event to dispatch.
     public func log(_ entry: LogEntry) {
         for sink in sinks {
             sink.write(entry)

--- a/Packages/Platform/Logging/Sources/Logging/InMemoryLogSink.swift
+++ b/Packages/Platform/Logging/Sources/Logging/InMemoryLogSink.swift
@@ -5,11 +5,55 @@
 //  Created by Ives Murillo on 3/16/26.
 //
 
+/// A ``LogSink`` that stores log entries in memory for inspection.
+///
+/// `InMemoryLogSink` is a **test double** — a concrete sink designed to be
+/// used in unit tests instead of production sinks like a console or remote
+/// service. After exercising code under test, you inspect `entries` to assert
+/// that the right messages were logged.
+///
+/// ## Why a class, not a struct?
+///
+/// `InMemoryLogSink` is a `class` because it is passed into `DefaultLogger`
+/// as `any LogSink` and then mutated (`entries.append`) from inside the logger.
+/// If it were a `struct`, the logger would hold a copy — appending to that copy
+/// would never be visible to your test. Using a reference type (`class`) means
+/// both your test and `DefaultLogger` share the same instance, so mutations
+/// are immediately observable.
+///
+/// This is a common Swift gotcha when working with protocols and value types:
+/// **if you need shared, observable mutation, use a reference type.**
+///
+/// ## Usage in tests
+///
+/// ```swift
+/// let sink = InMemoryLogSink()
+/// let logger = DefaultLogger(sinks: [sink])
+///
+/// logger.log(LogEntry(message: "user tapped login"))
+///
+/// #expect(sink.entries.count == 1)
+/// #expect(sink.entries[0].message == "user tapped login")
+/// ```
+///
+/// ## `private(set)` on `entries`
+///
+/// The `entries` array is readable by anyone but writable only by
+/// `InMemoryLogSink` itself. This enforces the invariant that entries are
+/// only ever added through ``write(_:)`` — the proper ``LogSink`` interface —
+/// never manipulated directly from outside.
+///
+/// - SeeAlso: ``LogSink``, ``LogEntry``, ``DefaultLogger``
 public final class InMemoryLogSink: LogSink {
+    /// The ordered list of entries written to this sink since it was created.
     public private(set) var entries: [LogEntry] = []
 
+    /// Creates an empty in-memory sink.
     public init() {}
 
+    /// Appends the entry to ``entries``.
+    ///
+    /// - Parameter entry: The log event to store.
     public func write(_ entry: LogEntry) {
         entries.append(entry)
     }

--- a/Packages/Platform/Logging/Sources/Logging/LogEntry.swift
+++ b/Packages/Platform/Logging/Sources/Logging/LogEntry.swift
@@ -5,9 +5,45 @@
 //  Created by Ives Murillo on 3/16/26.
 //
 
+/// An immutable value that represents a single log event in the system.
+///
+/// `LogEntry` is the core domain model of the `Logging` package. It is the
+/// structured record that travels through the pipeline from a ``Logger`` to
+/// one or more ``LogSink`` destinations.
+///
+/// ## Why a value type?
+///
+/// Using a `struct` makes each log event an independent, immutable snapshot.
+/// Once created, a `LogEntry` cannot be mutated — sinks receive exactly what
+/// was logged, with no risk of data races or accidental mutation as it passes
+/// through the pipeline. This is a key Swift pattern: model data as values,
+/// not references.
+///
+/// ## Why not just a `String`?
+///
+/// A raw string carries only the message. `LogEntry` is the place where richer
+/// metadata will live as the logging system grows — things like severity level,
+/// subsystem, category, source location, and timestamp. Encapsulating all of
+/// that in one type keeps ``LogSink`` implementations simple: they receive one
+/// value and decide what to do with it.
+///
+/// ## Planned evolution
+///
+/// Today `LogEntry` holds only a `message`. Future iterations will add:
+/// - `level: Level` — debug / info / warning / error
+/// - `subsystem: String` — mirrors `OSLog`'s subsystem concept
+/// - `category: String` — mirrors `OSLog`'s category concept
+/// - `timestamp: Date` — when the event occurred
+/// - `file`, `function`, `line` — source location via `#file`, `#function`, `#line`
+///
+/// - SeeAlso: ``Logger``, ``LogSink``
 public struct LogEntry {
+    /// The human-readable description of the log event.
     public let message: String
 
+    /// Creates a new log entry with the given message.
+    ///
+    /// - Parameter message: A human-readable description of the event being logged.
     public init(message: String) {
         self.message = message
     }

--- a/Packages/Platform/Logging/Sources/Logging/Logger.swift
+++ b/Packages/Platform/Logging/Sources/Logging/Logger.swift
@@ -5,10 +5,57 @@
 //  Created by Ives Murillo on 3/16/26.
 //
 
+/// A destination that receives and persists structured log entries.
+///
+/// `LogSink` is the output side of the logging pipeline. Each sink decides
+/// independently what to do with a `LogEntry` — write to the console, store
+/// in memory, send to a remote service, etc.
+///
+/// ## Designing a sink
+///
+/// A sink should do one thing and do it well. Compose multiple sinks inside
+/// `DefaultLogger` rather than building a sink that does many things.
+///
+/// ```swift
+/// struct ConsoleSink: LogSink {
+///     func write(_ entry: LogEntry) {
+///         print("[\(entry.message)]")
+///     }
+/// }
+/// ```
+///
+/// - Note: `InMemoryLogSink` is provided out of the box and is the recommended
+///   sink to use in unit tests.
 public protocol LogSink {
+    /// Receives a structured log entry and handles its persistence or output.
+    ///
+    /// - Parameter entry: The log event to write.
     func write(_ entry: LogEntry)
 }
 
+/// An object that accepts structured log entries and dispatches them to one
+/// or more ``LogSink`` destinations.
+///
+/// `Logger` is the internal contract of the `Logging` package. It works with
+/// ``LogEntry`` — a structured value that can carry rich metadata — rather than
+/// raw strings. This keeps the infrastructure layer decoupled from the simple
+/// string-based ``PlatformContracts/Logging`` protocol that feature modules use.
+///
+/// ## Relationship to `PlatformContracts.Logging`
+///
+/// Feature modules depend on `PlatformContracts.Logging` (`func log(_ string: String)`),
+/// not on this protocol. `AppCore` bridges the two by making `DefaultLogger`
+/// conform to `PlatformContracts.Logging`, wrapping the incoming string into a
+/// `LogEntry` before dispatching it through this pipeline.
+///
+/// ```
+/// Feature  →  PlatformContracts.Logging  →  DefaultLogger  →  [LogSink]
+/// ```
+///
+/// - SeeAlso: ``LogEntry``, ``LogSink``, ``DefaultLogger``
 public protocol Logger {
+    /// Dispatches a structured log entry to all configured sinks.
+    ///
+    /// - Parameter entry: The log event to dispatch.
     func log(_ entry: LogEntry)
 }


### PR DESCRIPTION
## Summary
Adds DocC documentation to all source files in the `Logging` package, turning it
into a self-explanatory learning module for understanding Swift and iOS logging patterns.

## Why
The `Logging` package is designed to grow into a complex feature for building mental
models around Swift infrastructure. Without documentation, the design intent, Swift
patterns in use, and relationship to `PlatformContracts` were invisible to the reader.

## Changes
- Updated `Logger.swift` — documented `LogSink` and `Logger` protocols, including
  the full pipeline diagram and their relationship to `PlatformContracts.Logging`
- Updated `LogEntry.swift` — documented why it is a value type, why it is not just
  a `String`, and mapped out its planned evolution toward a rich structured log event
  mirroring `OSLog`
- Updated `DefaultLogger.swift` — documented the Strategy pattern, why the class is
  `final`, how multi-sink composition works, and how `AppCore` will bridge it to
  `PlatformContracts.Logging`
- Updated `InMemoryLogSink.swift` — documented its role as a test double, why it is a
  `class` (shared mutation with protocol existentials), and the `private(set)` invariant

## Testing
- [x] Unit tests pass
- [x] App builds successfully
- [x] Verified manually in simulator

## Notes
No logic changes — documentation only. `Logging.swift` (empty placeholder) was
intentionally left untouched. A follow-up issue should wire the bridge extension
`DefaultLogger: PlatformContracts.Logging` inside `AppCore`.