### PR TITLE
feat: #24 LoggingAdapter + Logging registration in AppCore

### DIFF
--- a/Packages/AppCore/Package.swift
+++ b/Packages/AppCore/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
     dependencies: [
         .package(path: "../../Features/Resume"),
         .package(path: "../../Platform/Logging"),
+        .package(path: "../../Platform/PlatformContracts"),
     ],
     targets: [
         .target(
@@ -21,6 +22,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Resume", package: "Resume"),
                 .product(name: "Logging", package: "Logging"),
+                .product(name: "PlatformContracts", package: "PlatformContracts"),
             ]
         ),
         .testTarget(

--- a/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
+++ b/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
@@ -7,6 +7,8 @@
 
 import FeatureContracts
 import Foundation
+import Logging
+import PlatformContracts
 import SwiftUI
 import UIKit
 
@@ -100,6 +102,12 @@ public class CompositionRoot {
         do {
             try container.register(Environment.self) { _ in
                 self.environment
+            }
+
+            try container.register(PlatformContracts.Logging.self) { _ in
+                LoggingAdapter(
+                    logger: DefaultLogger(sinks: [InMemoryLogSink()])
+                )
             }
 
             try registry.registerAll(in: container)

--- a/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
+++ b/Packages/AppCore/Sources/AppCore/CompositionRoot.swift
@@ -142,7 +142,7 @@ public class CompositionRoot {
     /// - Note: Must be called on the main thread due to SwiftUI requirements
     @MainActor
     public func makeSwiftUIRoot() -> some View {
-        return RootView()
+        RootView()
     }
 
     /// A fallback implementation of `ResumeFeatureProviding` used when the actual provider

--- a/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
+++ b/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
@@ -5,4 +5,17 @@
 //  Created by Ives Murillo on 6/10/26.
 //
 
-import Foundation
+import Logging
+
+final class LoggingAdapter {
+
+    private let logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
+    func log(_ string: String) {
+        logger.log(LogEntry(message: string))
+    }
+}

--- a/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
+++ b/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
@@ -9,7 +9,6 @@ import Logging
 import PlatformContracts
 
 final class LoggingAdapter: PlatformContracts.Logging {
-
     private let logger: Logger
 
     init(logger: Logger) {

--- a/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
+++ b/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
@@ -8,13 +8,31 @@
 import Logging
 import PlatformContracts
 
+/// Bridges the platform `PlatformContracts.Logging` protocol to the concrete `Logging.Logger` infrastructure.
+///
+/// `LoggingAdapter` acts as an anti-corruption layer between the feature-facing logging contract
+/// and the platform logging implementation. Features depend only on `PlatformContracts.Logging`;
+/// the adapter is wired in `CompositionRoot` so the infrastructure detail stays out of domain code.
+///
+/// ## Usage
+///
+/// ```swift
+/// let adapter = LoggingAdapter(logger: DefaultLogger(sinks: [InMemoryLogSink()]))
+/// adapter.log("Session started")
+/// ```
 final class LoggingAdapter: PlatformContracts.Logging {
     private let logger: Logger
 
+    /// Creates an adapter that forwards log messages to the given `Logger`.
+    ///
+    /// - Parameter logger: The concrete logger that receives forwarded log entries.
     init(logger: Logger) {
         self.logger = logger
     }
 
+    /// Wraps `string` in a `LogEntry` and forwards it to the underlying logger.
+    ///
+    /// - Parameter string: The message to log.
     func log(_ string: String) {
         logger.log(LogEntry(message: string))
     }

--- a/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
+++ b/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
@@ -6,8 +6,9 @@
 //
 
 import Logging
+import PlatformContracts
 
-final class LoggingAdapter {
+final class LoggingAdapter: PlatformContracts.Logging {
 
     private let logger: Logger
 

--- a/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
+++ b/Packages/AppCore/Sources/AppCore/LoggingAdapter.swift
@@ -1,0 +1,8 @@
+//
+//  LoggingAdapter.swift
+//  AppCore
+//
+//  Created by Ives Murillo on 6/10/26.
+//
+
+import Foundation

--- a/Packages/AppCore/Tests/AppCoreTests/CompositionRootTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/CompositionRootTests.swift
@@ -6,6 +6,7 @@
 //
 
 @testable import AppCore
+import PlatformContracts
 import Testing
 import UIKit
 
@@ -98,6 +99,28 @@ struct CompositionRootTests {
 
         #expect(throws: Never.self) {
             _ = sut.makeSwiftUIRoot()
+        }
+    }
+
+    // MARK: Logging
+
+    @Suite("Container - logging")
+    struct ContainerTests {
+
+        @MainActor
+        @Test
+        func resolvesLoggingWithoutThrowing() throws {
+            // Arrange
+            let environment = Environment.development
+            let registry = FeatureRegistry(registrants: [])
+            let sut = CompositionRoot(
+                environment: environment,
+                registry: registry
+            )
+            // Act - Assert
+            #expect(throws: Never.self) {
+                try sut.container.resolve(Logging.self)
+            }
         }
     }
 }

--- a/Packages/AppCore/Tests/AppCoreTests/CompositionRootTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/CompositionRootTests.swift
@@ -106,7 +106,6 @@ struct CompositionRootTests {
 
     @Suite("Container - logging")
     struct ContainerTests {
-
         @MainActor
         @Test
         func resolvesLoggingWithoutThrowing() throws {

--- a/Packages/AppCore/Tests/AppCoreTests/LoggerSpy.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/LoggerSpy.swift
@@ -1,0 +1,19 @@
+//
+//  LoggerSpy.swift
+//  AppCore
+//
+//  Created by Ives Murillo on 6/10/26.
+//
+
+import Logging
+
+class LoggerSpy: Logger {
+    private(set) var receivedEntries: [LogEntry] = []
+    var receivedMessages: [String] {
+        receivedEntries.map(\.message)
+    }
+
+    func log(_ entry: Logging.LogEntry) {
+        receivedEntries.append(entry)
+    }
+}

--- a/Packages/AppCore/Tests/AppCoreTests/LoggerSpy.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/LoggerSpy.swift
@@ -7,7 +7,7 @@
 
 import Logging
 
-class LoggerSpy: Logger {
+final class LoggerSpy: Logger {
     private(set) var receivedEntries: [LogEntry] = []
     var receivedMessages: [String] {
         receivedEntries.map(\.message)

--- a/Packages/AppCore/Tests/AppCoreTests/LoggingAdapterTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/LoggingAdapterTests.swift
@@ -1,0 +1,8 @@
+//
+//  LoggingAdapterTests.swift
+//  AppCore
+//
+//  Created by Ives Murillo on 6/10/26.
+//
+
+import Foundation

--- a/Packages/AppCore/Tests/AppCoreTests/LoggingAdapterTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/LoggingAdapterTests.swift
@@ -24,4 +24,17 @@ struct LoggingAdapterTests {
             #expect(spy.receivedMessages == ["Test message"])
         }
     }
+
+    @Test
+    func forwardsMultipleMessages() {
+        // Arrange
+        let spy = LoggerSpy()
+        let sut = LoggingAdapter(logger: spy)
+        // Act
+        sut.log("First message")
+        sut.log("Second message")
+        sut.log("Third message")
+        // Assert
+        #expect(spy.receivedMessages == ["First message", "Second message", "Third message"])
+    }
 }

--- a/Packages/AppCore/Tests/AppCoreTests/LoggingAdapterTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/LoggingAdapterTests.swift
@@ -5,9 +5,9 @@
 //  Created by Ives Murillo on 6/10/26.
 //
 
-import Testing
-import Logging
 @testable import AppCore
+import Logging
+import Testing
 
 @Suite("Logging Adapter Tests")
 struct LoggingAdapterTests {

--- a/Packages/AppCore/Tests/AppCoreTests/LoggingAdapterTests.swift
+++ b/Packages/AppCore/Tests/AppCoreTests/LoggingAdapterTests.swift
@@ -5,4 +5,23 @@
 //  Created by Ives Murillo on 6/10/26.
 //
 
-import Foundation
+import Testing
+import Logging
+@testable import AppCore
+
+@Suite("Logging Adapter Tests")
+struct LoggingAdapterTests {
+    @Suite("Log")
+    struct LogTest {
+        @Test
+        func forwaresMessageToLogger() {
+            // Arrange
+            let spy = LoggerSpy()
+            let sut = LoggingAdapter(logger: spy)
+            // Act
+            sut.log("Test message")
+            // Assert
+            #expect(spy.receivedMessages == ["Test message"])
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds `LoggingAdapter` to `AppCore` and registers `Logging`
in the dependency container — completing the logging system
end to end.

## Why
`PlatformContracts.Logging` and `Platform.Logger` are two
separate protocols. `DefaultLogger` conforms to `Logger` —
not to `Logging`. Features resolving `Logging` from the
container had no concrete implementation behind it.
`ResolutionError.missingRegistration` would be thrown
silently in production.

This PR closes the open item identified in Discussion #2.
Platform services are now fully defined, wired, and tested.
Any feature can now resolve `Logging` from the container
without throwing.

## Changes

* Added `LoggingAdapter.swift` — bridges
  `PlatformContracts.Logging` and `Platform.Logger`.
  Translates `log(_ string: String)` into
  `logger.log(LogEntry(message: string))`.
  Lives in `AppCore` — the only package that imports both
  `PlatformContracts` and `Platform/Logging`.
  Conforms explicitly to `PlatformContracts.Logging`
  to avoid naming collision with the `Logging` module.

* Updated `CompositionRoot.makeContainer()` — registers
  `Logging` as a platform service before features.
  Registration order now final:
  `Environment` → `Logging` → Features.
  `LoggingAdapter` backed by `DefaultLogger`
  with `InMemoryLogSink` for v1.

* Added `LoggingAdapterTests.swift` — tests
  `LoggingAdapter` behavior using `LoggerSpy` as test double.
  No mocking framework. Sad path not applicable —
  `LoggingAdapter` is a pure translation layer with no
  failure mode.

* Added `CompositionRootTests` — logging suite verifies
  `container.resolve(PlatformContracts.Logging.self)`
  succeeds after registration.

* Added `LoggerSpy.swift` in `Helpers/` — `final class`
  conforming to `Platform.Logger`. Class semantics required
  — struct would be copied into existential box making
  entries invisible to the test.

## Testing

- [x] All unit tests pass
- [x] App builds successfully
- [x] No infrastructure changes — unit tests only
- [ ] Integration tests run on device (not applicable)

## Checklist

- [x] Domain layer has zero framework imports
- [x] No production code exists without a failing test
- [x] Sad path assessed — not applicable for pure translation layer
- [x] Test names read as plain English specifications
- [x] Commit history follows red → green → refactor convention
- [x] Issue linked and acceptance criteria met

## Notes

**Naming collision** — `Logging` module and
`PlatformContracts.Logging` protocol share the same name.
Resolved by using fully qualified type name
`PlatformContracts.Logging.self` everywhere both are
imported together. This should be addressed in a future
architecture discussion — a rename of either the module
or the protocol would eliminate the ambiguity permanently.

`InMemoryLogSink` used as the concrete sink for v1.
`ConsoleSink` and `CrashSink` are deferred to v2
as decided in Discussion #5.

Follow-up: issue #25 wires `Logging` into the
Resume feature use cases via init injection.