### PR TITLE
Feature/domain interview score

### DIFF
--- a/Apps/MySkillo/MySkillo.xcodeproj/xcshareddata/xcschemes/MySkillo-UIKit.xcscheme
+++ b/Apps/MySkillo/MySkillo.xcodeproj/xcshareddata/xcschemes/MySkillo-UIKit.xcscheme
@@ -30,7 +30,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:../../Packages/Features/Resume/Tests/Resume.xctestplan">
+            reference = "container:../../Packages/Features/Resume/Tests/Resume.xctestplan"
+            default = "YES">
          </TestPlanReference>
       </TestPlans>
       <Testables>

--- a/Packages/Features/Resume/Sources/Resume/Domain/Entities/CoachingReport.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/Entities/CoachingReport.swift
@@ -5,4 +5,32 @@
 //  Created by Ives Murillo on 6/6/26.
 //
 
-struct CoachingReport: Equatable {}
+import Foundation
+
+struct CoachingReport: Equatable {
+    static let maximunSuggestions = 3
+
+    let takeID: UUID
+    let overallScore: InterviewScore
+    let dimensionScores: [DimensionScore]
+    let suggestions: [Suggestion]
+    let generatedAt: Date
+
+    init?(
+        takeID: UUID,
+        overallScore: InterviewScore,
+        dimensionScores: [DimensionScore],
+        suggestions: [Suggestion],
+        generatedAt: Date
+    ) {
+        guard suggestions.count <=  CoachingReport.maximunSuggestions else {
+            return nil
+        }
+
+        self.takeID = takeID
+        self.overallScore = overallScore
+        self.dimensionScores = dimensionScores
+        self.suggestions = suggestions
+        self.generatedAt = generatedAt
+    }
+}

--- a/Packages/Features/Resume/Sources/Resume/Domain/Entities/CoachingReport.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/Entities/CoachingReport.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CoachingReport: Equatable {
-    static let maximunSuggestions = 3
+    static let maximumSuggestions: Int = 3
 
     let takeID: UUID
     let overallScore: InterviewScore
@@ -23,7 +23,7 @@ struct CoachingReport: Equatable {
         suggestions: [Suggestion],
         generatedAt: Date
     ) {
-        guard suggestions.count <=  CoachingReport.maximunSuggestions else {
+        guard suggestions.count <= CoachingReport.maximumSuggestions else {
             return nil
         }
 

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/DimensionScore.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/DimensionScore.swift
@@ -5,7 +5,7 @@
 //  Created by Ives Murillo on 7/1/26.
 //
 
-struct DimensionScore {
+struct DimensionScore: Equatable {
     let dimension: DimensionType
     let score: InterviewScore
 }

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/DimensionScore.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/DimensionScore.swift
@@ -1,0 +1,11 @@
+//
+//  DimensionScore.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/1/26.
+//
+
+struct DimensionScore {
+    let dimension: DimensionType
+    let score: InterviewScore
+}

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/DimensionType.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/DimensionType.swift
@@ -1,0 +1,14 @@
+//
+//  DimensionType.swift
+//  Resume
+//
+//  Created by Ives Murillo on 6/30/26.
+//
+
+enum DimensionType: CaseIterable, Equatable {
+    case technicalDepth
+    case eyeContact
+    case pacing
+    case structure
+    case fillerWords
+}

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/InterviewScore.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/InterviewScore.swift
@@ -1,0 +1,15 @@
+//
+//  InterviewScore.swift
+//  Resume
+//
+//  Created by Ives Murillo on 6/30/26.
+//
+
+struct InterviewScore: Codable, Equatable {
+    let score: Int
+
+    init?(_ score: Int) {
+        guard score >= 0, score <= 100 else { return nil }
+        self.score = score
+    }
+}

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/Sugestions.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/Sugestions.swift
@@ -1,0 +1,11 @@
+//
+//  File.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/16/26.
+//
+
+struct Suggestion {
+    let dimension: DimensionType
+    let description: RequiredText
+}

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/Sugestions.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/Sugestions.swift
@@ -5,7 +5,7 @@
 //  Created by Ives Murillo on 7/16/26.
 //
 
-struct Suggestion {
+struct Suggestion: Equatable {
     let dimension: DimensionType
-    let description: RequiredText
+    let text: RequiredText
 }

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/Sugestions.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/Sugestions.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Sugestions.swift
 //  Resume
 //
 //  Created by Ives Murillo on 7/16/26.

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/CoachingReportTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/CoachingReportTests.swift
@@ -5,16 +5,14 @@
 //  Created by Ives Murillo on 6/30/26.
 //
 
-@testable import Resume
 import Foundation
 import Testing
+@testable import Resume
 
 @Suite("CoachingReport")
 struct CoachingReportTests {
-
     @Suite("init")
     struct InitTests {
-        // Arrange
         let sugestion1 = Suggestion(
             dimension: .eyeContact,
             text: .init("keep eye contact")!
@@ -32,10 +30,8 @@ struct CoachingReportTests {
             text: .init("improve struture")!
         )
 
-
         @Test("With more than limit suggestions fail")
         func init_withMoreThanLimitSuggestionsFail() {
-
             let suggestions = [sugestion1, sugestion2, sugestion3, sugestion4]
             // Act
             let sut = CoachingReportFactory.make(suggestion: suggestions)
@@ -81,11 +77,10 @@ struct CoachingReportTests {
             #expect(sut?.dimensionScores == dimensionScores)
             #expect(sut?.generatedAt == generatedAt)
         }
-
     }
 }
 
-struct CoachingReportFactory {
+enum CoachingReportFactory {
     static func make(
         takeID: UUID = .init(),
         overallScore: InterviewScore = .init(82)!,

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/CoachingReportTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/CoachingReportTests.swift
@@ -1,0 +1,104 @@
+//
+//  CoachingReportTests.swift
+//  Resume
+//
+//  Created by Ives Murillo on 6/30/26.
+//
+
+@testable import Resume
+import Foundation
+import Testing
+
+@Suite("CoachingReport")
+struct CoachingReportTests {
+
+    @Suite("init")
+    struct InitTests {
+        // Arrange
+        let sugestion1 = Suggestion(
+            dimension: .eyeContact,
+            text: .init("keep eye contact")!
+        )
+        let sugestion2 = Suggestion(
+            dimension: .fillerWords,
+            text: .init("avoid filling words")!
+        )
+        let sugestion3 = Suggestion(
+            dimension: .pacing,
+            text: .init("pacing too fast")!
+        )
+        let sugestion4 = Suggestion(
+            dimension: .structure,
+            text: .init("improve struture")!
+        )
+
+
+        @Test("With more than limit suggestions fail")
+        func init_withMoreThanLimitSuggestionsFail() {
+
+            let suggestions = [sugestion1, sugestion2, sugestion3, sugestion4]
+            // Act
+            let sut = CoachingReportFactory.make(suggestion: suggestions)
+            // Assert
+            #expect(sut == nil)
+        }
+
+        @Test("with less or equal to limit of suggestions succed")
+        func init_withLessOrEqualToLimitSuggestionsSucced() {
+            // Assert
+            let suggestions = [sugestion1, sugestion2, sugestion3]
+            // Act
+            let sut = CoachingReportFactory.make(suggestion: suggestions)
+            // Assert
+            #expect(sut != nil)
+        }
+
+        @Test("with zero suggestions succed")
+        func init_withSZeroSuggestionsSucced() {
+            // Act
+            let sut = CoachingReportFactory.make(suggestion: [])
+            // Assert
+            #expect(sut != nil)
+        }
+
+        @Test("Has correct properties")
+        func init_hasCorrectProperties() {
+            // Arrange
+            let takeId = UUID()
+            let overallScore = InterviewScore(82)!
+            let dimensionScores = [DimensionScore(dimension: .fillerWords, score: InterviewScore(82)!)]
+            let generatedAt = Date()
+            // Act
+            let sut = CoachingReportFactory.make(
+                takeID: takeId,
+                overallScore: overallScore,
+                dimensionScores: dimensionScores,
+                generatedAt: generatedAt
+            )
+            // Assert
+            #expect(sut?.takeID == takeId)
+            #expect(sut?.overallScore == overallScore)
+            #expect(sut?.dimensionScores == dimensionScores)
+            #expect(sut?.generatedAt == generatedAt)
+        }
+
+    }
+}
+
+struct CoachingReportFactory {
+    static func make(
+        takeID: UUID = .init(),
+        overallScore: InterviewScore = .init(82)!,
+        dimensionScores: [DimensionScore] = [],
+        suggestion: [Suggestion] = [],
+        generatedAt: Date = .init()
+    ) -> CoachingReport? {
+        CoachingReport(
+            takeID: takeID,
+            overallScore: overallScore,
+            dimensionScores: dimensionScores,
+            suggestions: suggestion,
+            generatedAt: generatedAt
+        )
+    }
+}

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/CoachingReportTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/CoachingReportTests.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import Testing
 @testable import Resume
+import Testing
 
 @Suite("CoachingReport")
 struct CoachingReportTests {
@@ -58,11 +58,12 @@ struct CoachingReportTests {
         }
 
         @Test("Has correct properties")
-        func init_hasCorrectProperties() {
+        func init_hasCorrectProperties() throws {
             // Arrange
             let takeId = UUID()
-            let overallScore = InterviewScore(82)!
-            let dimensionScores = [DimensionScore(dimension: .fillerWords, score: InterviewScore(82)!)]
+            let overallScore = try #require(InterviewScore(82))
+            let dimensionScore = try #require(InterviewScore(82))
+            let dimensionScores = [DimensionScore(dimension: .fillerWords, score: dimensionScore)]
             let generatedAt = Date()
             // Act
             let sut = CoachingReportFactory.make(

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/TakeTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/TakeTests.swift
@@ -139,7 +139,7 @@ struct TakeTests {
             // Assert
             guard case let .failed(storederror) = sut else {
                 Issue.record("Expected failed status")
-                return 
+                return
             }
             #expect(storederror == error)
         }

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/TakeTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/TakeTests.swift
@@ -35,10 +35,9 @@ struct TakeTests {
         }
 
         @available(iOS 16.0, *)
-        @Test func whenStatusIsAnalyzed_returnsFalse() {
+        @Test func whenStatusIsAnalyzed_returnsFalse() throws {
             // Arrange
-            let suggestions = Suggestion.sample
-            let report = CoachingReportFactory.make()!
+            let report = try #require(CoachingReportFactory.make())
             let sut = Take.make(status: .analyzed(report))
             // Act
             let result = sut.isAnalyzable
@@ -70,10 +69,9 @@ struct TakeTests {
     @Suite("Is Promotable test")
     struct IsPromotableTests {
         @available(iOS 16.0, *)
-        @Test func whenStatusIsAnalyzed_returnsTrue() {
+        @Test func whenStatusIsAnalyzed_returnsTrue() throws {
             // Arrange
-            let suggestions = Suggestion.sample
-            let report = CoachingReportFactory.make()!
+            let report = try #require(CoachingReportFactory.make())
             let sut = Take.make(status: .analyzed(report))
             // Act
             let result = sut.isPromotable
@@ -115,10 +113,9 @@ struct TakeTests {
     @Suite("TakeStatus tests")
     struct TakeStatusTests {
         @Test
-        func analyzedStatus_storesCoachingReport() {
+        func analyzedStatus_storesCoachingReport() throws {
             // Arrange
-            let suggestions = Suggestion.sample
-            let report = CoachingReportFactory.make()!
+            let report = try #require(CoachingReportFactory.make())
             // Act
             let sut = TakeStatus.analyzed(report)
 

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/TakeTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/TakeTests.swift
@@ -37,7 +37,8 @@ struct TakeTests {
         @available(iOS 16.0, *)
         @Test func whenStatusIsAnalyzed_returnsFalse() {
             // Arrange
-            let report = CoachingReport()
+            let suggestions = Suggestion.sample
+            let report = CoachingReportFactory.make()!
             let sut = Take.make(status: .analyzed(report))
             // Act
             let result = sut.isAnalyzable
@@ -71,7 +72,8 @@ struct TakeTests {
         @available(iOS 16.0, *)
         @Test func whenStatusIsAnalyzed_returnsTrue() {
             // Arrange
-            let report = CoachingReport()
+            let suggestions = Suggestion.sample
+            let report = CoachingReportFactory.make()!
             let sut = Take.make(status: .analyzed(report))
             // Act
             let result = sut.isPromotable
@@ -115,7 +117,8 @@ struct TakeTests {
         @Test
         func analyzedStatus_storesCoachingReport() {
             // Arrange
-            let report = CoachingReport()
+            let suggestions = Suggestion.sample
+            let report = CoachingReportFactory.make()!
             // Act
             let sut = TakeStatus.analyzed(report)
 
@@ -136,6 +139,7 @@ struct TakeTests {
             // Assert
             guard case let .failed(storederror) = sut else {
                 Issue.record("Expected failed status")
+                return 
             }
             #expect(storederror == error)
         }

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/DimensionScoreTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/DimensionScoreTests.swift
@@ -10,7 +10,6 @@ import Testing
 
 @Suite("DimensionScore")
 struct DimensionScoreTests {
-
     @Test("DimensionScore has correct properties")
     func hasCorrectProperties() {
         // Arrange
@@ -20,6 +19,4 @@ struct DimensionScoreTests {
         #expect(sut.dimension == .technicalDepth)
         #expect(sut.score == score)
     }
-
 }
-

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/DimensionScoreTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/DimensionScoreTests.swift
@@ -1,0 +1,25 @@
+//
+//  DimensionScoreTests.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/1/26.
+//
+
+@testable import Resume
+import Testing
+
+@Suite("DimensionScore")
+struct DimensionScoreTests {
+
+    @Test("DimensionScore has correct properties")
+    func hasCorrectProperties() {
+        // Arrange
+        let score = InterviewScore(10)!
+        let sut = DimensionScore(dimension: .technicalDepth, score: score)
+        // Act-Assert
+        #expect(sut.dimension == .technicalDepth)
+        #expect(sut.score == score)
+    }
+
+}
+

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/DimensionScoreTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/DimensionScoreTests.swift
@@ -11,9 +11,9 @@ import Testing
 @Suite("DimensionScore")
 struct DimensionScoreTests {
     @Test("DimensionScore has correct properties")
-    func hasCorrectProperties() {
+    func hasCorrectProperties() throws {
         // Arrange
-        let score = InterviewScore(10)!
+        let score = try #require(InterviewScore(10))
         let sut = DimensionScore(dimension: .technicalDepth, score: score)
         // Act-Assert
         #expect(sut.dimension == .technicalDepth)

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/InterviewScoreTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/InterviewScoreTests.swift
@@ -1,0 +1,30 @@
+//
+//  InterviewScoreTests.swift
+//  Resume
+//
+//  Created by Ives Murillo on 6/30/26.
+//
+
+@testable import Resume
+import Testing
+
+@Suite("InterviewScore")
+struct InterviewScoreTests {
+    @Suite("init")
+    struct InitTests {
+        @Test
+        func whenAbove100_returnsNil() {
+            #expect(InterviewScore(101) == nil)
+        }
+
+        @Test
+        func whenBelow0_returnsNil() {
+            #expect(InterviewScore(-1) == nil)
+        }
+
+        @Test
+        func whenValidScore_returnInstance() {
+            #expect(InterviewScore(40) != nil)
+        }
+    }
+}

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/SuggestionsTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/SuggestionsTests.swift
@@ -1,0 +1,30 @@
+//
+//  File.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/16/26.
+//
+
+@testable import Resume
+import Testing
+
+@Suite("Suggestion Test")
+struct SuggestionsTests {
+    @Suite("Intit Tests")
+    struct Initializer {
+        @Test("Init")
+        func init_hasCorrectProperties() {
+            // Arrange
+            let dimension: DimensionType = .eyeContact
+            let description: RequiredText = .init("keep eye contact")!
+            // Act
+            let sut = Suggestion(
+                dimension: dimension,
+                description: description
+            )
+            // Assert
+            #expect(sut.dimension == dimension)
+            #expect(sut.description == description)
+        }
+    }
+}

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/SuggestionsTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/SuggestionsTests.swift
@@ -13,10 +13,10 @@ struct SuggestionsTests {
     @Suite("Intit Tests")
     struct Initializer {
         @Test("Init")
-        func init_hasCorrectProperties() {
+        func init_hasCorrectProperties() throws {
             // Arrange
             let dimension: DimensionType = .eyeContact
-            let description: RequiredText = .init("keep eye contact")!
+            let description: RequiredText = try #require(.init("keep eye contact"))
             // Act
             let sut = Suggestion(
                 dimension: dimension,

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/SuggestionsTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/SuggestionsTests.swift
@@ -20,11 +20,28 @@ struct SuggestionsTests {
             // Act
             let sut = Suggestion(
                 dimension: dimension,
-                description: description
+                text: description
             )
             // Assert
             #expect(sut.dimension == dimension)
-            #expect(sut.description == description)
+            #expect(sut.text == description)
         }
     }
+}
+
+extension Suggestion {
+    static let sample = [
+        Suggestion(
+            dimension: .eyeContact,
+            text: .init("keep eye contact")!
+        ),
+        Suggestion(
+            dimension: .fillerWords,
+            text: .init("avoid filling words")!
+        ),
+        Suggestion(
+            dimension: .pacing,
+            text: .init("pacing too fast")!
+        )
+    ]
 }

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/SuggestionsTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/SuggestionsTests.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  SuggestionsTests.swift
 //  Resume
 //
 //  Created by Ives Murillo on 7/16/26.
@@ -42,6 +42,6 @@ extension Suggestion {
         Suggestion(
             dimension: .pacing,
             text: .init("pacing too fast")!
-        )
+        ),
     ]
 }


### PR DESCRIPTION
## Summary
Adds `CoachingReport` domain entity and its supporting
value objects — `DimensionType`, `DimensionScore`, and `Suggestion`.

## Why
`CoachingReport` is the result of analyzing a `Take`.
Without it the analysis pipeline has nowhere to store
its output and the report card screen has nothing to display.

Before this PR — the domain had no way to represent
coaching feedback. Dimension scores were untyped.
Suggestion text was a raw `String` with no enforcement.
The maximum suggestions business rule existed only
in the PRD — not in the type system.

After this PR — coaching feedback is fully type-safe:
- Dimension types are an enum — invalid dimensions are unrepresentable
- Scores are `InterviewScore` — invalid scores are impossible
- Suggestion text is `RequiredText` — empty suggestions cannot exist
- More than `maximumSuggestions` suggestions cannot be stored —
  enforced by failable init, not by the caller

## Changes

* Added `DimensionType.swift` — enum value object with five cases:
  `.technicalDepth` `.eyeContact` `.pacing` `.structure` `.fillerWords`.
  Enum chosen over struct — the domain has a fixed set of valid
  dimensions. All other dimensions are unrepresentable.

* Added `DimensionScore.swift` — value object composing a
  `DimensionType` and an `InterviewScore`. No failable init needed —
  both properties are already validated types.

* Added `Suggestion.swift` — value object composing a `DimensionType`
  and `RequiredText`. No failable init needed — both properties
  are already validated types. `text` chosen over `description`
  to avoid collision with Swift's `CustomStringConvertible`
  and to better reflect domain language.

* Added `CoachingReport.swift` — domain entity with `id`, `takeId`,
  `overallScore`, `dimensionScores`, `suggestions`, `generatedAt`.
  Failable init enforces `suggestions.count <= maximumSuggestions`.
  `maximumSuggestions` is a static constant — changing the limit
  requires a change in one place only. Zero suggestions is valid —
  it means the answer was perfect and no coaching is needed.

* Added `DimensionScoreTests.swift` — structural test verifying
  correct property assignment. No boundary tests needed —
  constraints enforced by composed types.

* Added `SuggestionTests.swift` — structural test verifying
  correct property assignment.

* Added `CoachingReportTests.swift` — full test coverage for
  the failable init business rule. Sad path first.
  Four suggestions returns nil. Three succeeds. Zero succeeds.
  Structural test verifies all properties via factory.

* Added `CoachingReportFactory.swift` in `Helpers/` — test factory
  providing valid default `CoachingReport` instances. Tests only
  specify what they care about. Adding new properties to
  `CoachingReport` requires updating the factory only —
  existing tests remain unchanged.

## BDD scenarios covered

- Feature 3, Scenario 1: Analysis pipeline completes successfully
- Feature 4, Scenario 2: Report card displays top 3 suggestions
- Feature 4, Scenario 3: CoachingReport cannot have more than 3 suggestions

## Testing

- [x] All unit tests pass
- [x] App builds successfully
- [x] No infrastructure changes — unit tests only
- [ ] Integration tests run on device (not applicable — domain layer)

## Checklist

- [x] Domain layer has zero framework imports
- [x] No production code exists without a failing test
- [x] Sad path tests written before happy path
- [x] Test names read as plain English specifications
- [x] Commit history follows red → green → refactor convention
- [x] Issue linked and acceptance criteria met

## Notes

`DimensionScore` was initially placed in `Domain/Entities/`
but corrected to `Domain/ValueObjects/` — it has no identity,
defined entirely by its dimension and score values.

`Suggestion.text` uses `RequiredText` — renamed from
`NonEmptyString` in ticket #2 to better reflect domain language.
Issue #3 acceptance criteria references `NonEmptyString` —
this is superseded by the rename decision in ticket #2.

`CoachingReport.maximumSuggestions` is `3` for v1.
Changing the limit requires updating one constant —
all tests using `CoachingReport.maximumSuggestions + 1`
remain correct automatically.

Follow-up: `InterviewScore` built on a separate branch
`feature/domain-interview-score` — merged independently.
`CoachingReport.overallScore` uses `InterviewScore` directly.