### PR TITLE
Feature: Adds all remaining constrained value objects

### DIFF
--- a/Packages/Features/Resume/Sources/Resume/Domain/Entities/VideoResume.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/Entities/VideoResume.swift
@@ -1,0 +1,24 @@
+//
+//  VideoResume.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+import Foundation
+
+@available(iOS 16.0, *)
+struct VideoResume: Equatable {
+    let takeId: UUID
+    let promotedAt: Date
+
+    init?(from take: Take) {
+        guard take.isPromotable else { return nil }
+        self.takeId = take.id
+        self.promotedAt = Date()
+    }
+
+    static func == (lhs: VideoResume, rhs: VideoResume) -> Bool {
+        lhs.takeId == rhs.takeId
+    }
+}

--- a/Packages/Features/Resume/Sources/Resume/Domain/Entities/VideoResume.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/Entities/VideoResume.swift
@@ -14,8 +14,8 @@ struct VideoResume: Equatable {
 
     init?(from take: Take) {
         guard take.isPromotable else { return nil }
-        self.takeId = take.id
-        self.promotedAt = Date()
+        takeId = take.id
+        promotedAt = Date()
     }
 
     static func == (lhs: VideoResume, rhs: VideoResume) -> Bool {

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/FillerWordCount.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/FillerWordCount.swift
@@ -1,0 +1,15 @@
+//
+//  FillerWordCount.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+struct FillerWordCount: Equatable {
+    let count: Int
+
+    init?(_ count: Int) {
+        guard count >= 0 else { return nil }
+        self.count = count
+    }
+}

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/PacingAssessment.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/PacingAssessment.swift
@@ -12,4 +12,3 @@ enum PacingAssessment {
     case slightlyAboveIdeal
     case tooFast
 }
-

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/PacingAssessment.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/PacingAssessment.swift
@@ -1,0 +1,15 @@
+//
+//  PacingAssessment.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+enum PacingAssessment {
+    case tooSlow
+    case slightlyBelowIdeal
+    case ideal
+    case slightlyAboveIdeal
+    case tooFast
+}
+

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/TakeDuration.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/TakeDuration.swift
@@ -9,7 +9,7 @@ struct TakeDuration: Equatable {
     let duration: Int
 
     init?(_ duration: Int) {
-        guard duration > 0 && duration < 91 else { return nil }
+        guard duration > 0, duration < 91 else { return nil }
         self.duration = duration
     }
 

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/TakeDuration.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/TakeDuration.swift
@@ -1,0 +1,19 @@
+//
+//  TakeDuration.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+struct TakeDuration: Equatable {
+    let duration: Int
+
+    init?(_ duration: Int) {
+        guard duration > 0 && duration < 91 else { return nil }
+        self.duration = duration
+    }
+
+    var isRecommendedRange: Bool {
+        duration >= 60
+    }
+}

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/WordsPerMinute.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/WordsPerMinute.swift
@@ -9,17 +9,17 @@ struct WordsPerMinute: Equatable {
     let value: Int
 
     init?(_ value: Int) {
-        guard value > 0 && value <= 300 else { return nil }
+        guard value > 0, value <= 300 else { return nil }
         self.value = value
     }
 
     var pacingAssessment: PacingAssessment {
         switch value {
-        case 0...99: return .tooSlow
-        case 100...129: return .slightlyBelowIdeal
-        case 130...160: return .ideal
-        case 161...180: return .slightlyAboveIdeal
-        case 181...300: return .tooFast
+        case 0 ... 99: return .tooSlow
+        case 100 ... 129: return .slightlyBelowIdeal
+        case 130 ... 160: return .ideal
+        case 161 ... 180: return .slightlyAboveIdeal
+        case 181 ... 300: return .tooFast
         default: preconditionFailure("WPM \(value) outside valid range 1-300")
         }
     }

--- a/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/WordsPerMinute.swift
+++ b/Packages/Features/Resume/Sources/Resume/Domain/ValueObjects/WordsPerMinute.swift
@@ -1,0 +1,26 @@
+//
+//  WordsPerMinute.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+struct WordsPerMinute: Equatable {
+    let value: Int
+
+    init?(_ value: Int) {
+        guard value > 0 && value <= 300 else { return nil }
+        self.value = value
+    }
+
+    var pacingAssessment: PacingAssessment {
+        switch value {
+        case 0...99: return .tooSlow
+        case 100...129: return .slightlyBelowIdeal
+        case 130...160: return .ideal
+        case 161...180: return .slightlyAboveIdeal
+        case 181...300: return .tooFast
+        default: preconditionFailure("WPM \(value) outside valid range 1-300")
+        }
+    }
+}

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/VideoResumeTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/Entities/VideoResumeTests.swift
@@ -1,0 +1,63 @@
+//
+//  VideoResumeTests.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+import Foundation
+@testable import Resume
+import Testing
+
+@Suite("Video Resume Tests")
+struct VideoResumeTests {
+    @Suite("init")
+    struct InitTests {
+        @available(iOS 16.0, *)
+        @Test("Can not be created from a non-promotable Take")
+        func whitNonPromotableTake_fail() {
+            // Arrange
+            let take = Take.make(status: .recorded)
+            // Act & Assert
+            #expect(VideoResume(from: take) == nil)
+        }
+
+        @available(iOS 16.0, *)
+        @Test("Can be created from a promotable Take")
+        func whitPromotableTake_Succed() throws {
+            // Arrange
+            let coachingReport = try #require(CoachingReportFactory.make())
+            let take = Take.make(status: .analyzed(coachingReport))
+            // Act & Assert
+            #expect(VideoResume(from: take) != nil)
+        }
+
+        @available(iOS 16.0, *)
+        @Test("Has correct properties")
+        func hasCorrectProperties() throws {
+            // Arrange
+            let before = Date()
+            let coachingReport = try #require(CoachingReportFactory.make())
+            let take = Take.make(status: .analyzed(coachingReport))
+            // Act
+            let sut = try #require(VideoResume(from: take))
+            let after = Date()
+            // Assert
+            #expect(sut.promotedAt >= before)
+            #expect(sut.promotedAt <= after)
+        }
+
+        @available(iOS 16.0, *)
+        @Test("Two video with sawe Take are equal")
+        func withSameTakeId_areEqual() throws {
+            // Arrange
+            let coachingReport = try #require(CoachingReportFactory.make())
+            let take = Take.make(status: .analyzed(coachingReport))
+            // Act
+            let sutA = try #require(VideoResume(from: take))
+            let sutB = try #require(VideoResume(from: take))
+            // Assert
+            #expect(sutA == sutB)
+        }
+    }
+}

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/FillerWordCountTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/FillerWordCountTests.swift
@@ -1,0 +1,27 @@
+//
+//  FillerWordCountTests.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+@testable import Resume
+import Testing
+
+@Suite("FillerWords Tests")
+struct FillerWordCountTests {
+    @Test("Can not be created with negative values")
+    func withNegativeValues_fail() {
+        #expect(FillerWordCount(-2) == nil)
+    }
+
+    @Test("Can be created with zero value")
+    func withZeroValue_succeeds() {
+        #expect(FillerWordCount(0) != nil)
+    }
+
+    @Test("Can be created with valid values")
+    func withValidValue_succeeds() {
+        #expect(FillerWordCount(4) != nil)
+    }
+}

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/PacingAssessmentTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/PacingAssessmentTests.swift
@@ -1,0 +1,27 @@
+//
+//  PacingAssessmentTests.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+@testable import Resume
+import Testing
+
+@Suite("PacingAssessment Tests")
+struct PacingAssessmentTests {
+
+    @Test("Has all required cases")
+    func hasAllCases() {
+        // Arrange
+        let cases: [PacingAssessment] = [
+            .tooSlow,
+            .slightlyBelowIdeal,
+            .ideal,
+            .slightlyAboveIdeal,
+            .tooFast
+        ]
+        // Act & Assert
+        #expect(cases.count == 5)
+    }
+}

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/PacingAssessmentTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/PacingAssessmentTests.swift
@@ -10,7 +10,6 @@ import Testing
 
 @Suite("PacingAssessment Tests")
 struct PacingAssessmentTests {
-
     @Test("Has all required cases")
     func hasAllCases() {
         // Arrange
@@ -19,7 +18,7 @@ struct PacingAssessmentTests {
             .slightlyBelowIdeal,
             .ideal,
             .slightlyAboveIdeal,
-            .tooFast
+            .tooFast,
         ]
         // Act & Assert
         #expect(cases.count == 5)

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/TakeDurationTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/TakeDurationTests.swift
@@ -1,0 +1,51 @@
+//
+//  TakeDurationTests.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+@testable import Resume
+import Testing
+
+@Suite("TakeDuration Tests")
+struct TakeDurationTests {
+    @Test("Cannot be created above maximum duration")
+    func whenAboveMaximum_returnsNil() {
+        #expect(TakeDuration(91) == nil)
+    }
+
+    @Test("Cannot be created below minimum duration")
+    func whenBelowMinimum_returnsNil() {
+        #expect(TakeDuration(0) == nil)
+    }
+
+    @Test("Can be created with valid duration")
+    func whenValidDuration_succeeds() {
+        #expect(TakeDuration(60) != nil)
+    }
+
+    @Test("Is in recommended range at lower boundary")
+    func withLowerBoundaryOfRecommendedRange_isInRecommendedRange() throws {
+        // Arrange
+        let sut = try #require(TakeDuration(60))
+        // Act & Assert
+        #expect(sut.isRecommendedRange == true)
+    }
+
+    @Test("Is in recommended range at upper boundary")
+    func withUpperBoundaryOfRecommendedRange_isInRecommendedRange() throws {
+        // Arrange
+        let sut = try #require(TakeDuration(90))
+        // Act & Assert
+        #expect(sut.isRecommendedRange == true)
+    }
+
+    @Test("Is not recommended range below 60 seconds")
+    func withBelowRecommendedRange_isNotInRecommendedRange() throws {
+        // Arrange
+        let sut = try #require(TakeDuration(59))
+        // Act & Assert
+        #expect(sut.isRecommendedRange == false)
+    }
+}

--- a/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/WordsPerMinuteTests.swift
+++ b/Packages/Features/Resume/Tests/ResumeTests/Domain/ValueObjects/WordsPerMinuteTests.swift
@@ -1,0 +1,116 @@
+//
+//  WordsPerMinuteTests.swift
+//  Resume
+//
+//  Created by Ives Murillo on 7/20/26.
+//
+
+@testable import Resume
+import Testing
+
+@Suite("WordsPerMinute Tests")
+struct WordsPerMinuteTests {
+    @Test("Cannot be construced with zero value")
+    func withZeroValue_returnsNil() {
+        // Act & Assert
+        #expect(WordsPerMinute(0) == nil)
+    }
+
+    @Test("Cannot be construced with negative value")
+    func withNegativeValue_returnsNil() {
+        // Act & Assert
+        #expect(WordsPerMinute(-1) == nil)
+    }
+
+    @Test("Cannot be construced with above maximum 300 wpm")
+    func withGreaterThanMaximumValue_returnsNil() {
+        // Act & Assert
+        #expect(WordsPerMinute(301) == nil)
+    }
+
+    @Test("Can be construced with valid value")
+    func withValidValue_returnsValue() {
+        // Act & Assert
+        #expect(WordsPerMinute(140) != nil)
+    }
+
+    @Test("Pacing is ideal for lower boundary of ideal range")
+    func withLowerBoundaryOfIdealRange_returnsIdeal() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(130))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .ideal)
+    }
+
+    @Test("Pacing is ideal for upper boundary of ideal range")
+    func withUpperBoundaryOfIdealRange_returnsIdeal() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(160))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .ideal)
+    }
+
+    @Test("Pacing is slightly below ideal at lower boundary")
+    func withLowerBoundaryOfSlightlyBelowRange_returnsSlightlyBelowRange() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(100))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .slightlyBelowIdeal)
+    }
+
+    @Test("Pacing is slightly below ideal at upper boundary")
+    func withUpperBoundaryOfSlightlyBelowRange_returnsSlightlyBelowRange() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(129))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .slightlyBelowIdeal)
+    }
+
+    @Test("Pacing is slightly above ideal at lower boundary")
+    func withLowerBoundaryOfSlightlyAboveRange_returnsSlightlyAboveRange() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(161))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .slightlyAboveIdeal)
+    }
+
+    @Test("Pacing is slightly above ideal at upper boundary")
+    func withUpperBoundaryOfSlightlyAboveRange_returnsSlightlyAboveRange() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(180))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .slightlyAboveIdeal)
+    }
+
+    @Test("Pacing is too fast at lower boundary")
+    func withLowerBoundaryOfTooFastRange_returnsTooFastRange() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(181))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .tooFast)
+    }
+
+    @Test("Pacing is too fast at upper boundary")
+    func withUpperBoundaryOfTooFastRange_returnsTooFastRange() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(300))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .tooFast)
+    }
+
+    @Test("Pacing is too slow at lower boundary")
+    func withLowerBoundaryOfTooSlowRange_returnsTooSlowRange() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(1))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .tooSlow)
+    }
+
+    @Test("Pacing is too slow at upper boundary")
+    func withUpperBoundaryOfTooSlowRange_returnsTooSlowRange() throws {
+        // Arrange
+        let sut = try #require(WordsPerMinute(99))
+        // Act & Assert
+        #expect(sut.pacingAssessment == .tooSlow)
+    }
+}


### PR DESCRIPTION
## Summary
Adds all remaining constrained value objects for the
Resume domain layer — `TakeDuration`, `FillerWordCount`,
`WordsPerMinute`, and `PacingAssessment`.

## Why
Raw primitives crossing domain boundaries are a liability.
A negative filler word count, a recording longer than
90 seconds, or a words-per-minute value of zero are all
invalid domain states that a raw `Int` cannot prevent.

Before this PR — these constraints existed only in
comments and documentation. Any caller could pass
invalid values and the compiler would say nothing.

After this PR — every constrained value has its own
type. Invalid construction is impossible. The compiler
enforces the domain rules — not the caller.

## Changes

* Added `PacingAssessment.swift` — enum value object
  with five cases: `.tooSlow` `.slightlyBelowIdeal`
  `.ideal` `.slightlyAboveIdeal` `.tooFast`.
  Enum chosen — the domain has a fixed set of valid
  pacing assessments. All other assessments are
  unrepresentable.

* Added `WordsPerMinute.swift` — value object enforcing
  positive integer values between 1 and 300. Maximum of
  300 chosen as a safety boundary — physically impossible
  to exceed in normal speech. `pacingAssessment` computed
  property maps WPM to `PacingAssessment` using defined
  ranges:
  tooSlow (1–99) · slightlyBelowIdeal (100–129) ·
  ideal (130–160) · slightlyAboveIdeal (161–180) ·
  tooFast (181–300).
  `preconditionFailure` used as default case — `init?`
  guarantees 1–300 so any default hit is a programming
  error worth crashing for.

* Added `TakeDuration.swift` — value object enforcing
  integer seconds between 0 and 90. `Int` chosen over
  `Double` — interview answers are measured in whole
  seconds, sub-second precision adds no domain value.
  `isInRecommendedRange` computed property returns `true`
  for 60–90 seconds — the ideal answer length range.

* Added `FillerWordCount.swift` — value object enforcing
  non-negative integer word count. Zero is valid — it
  means no filler words were detected, a perfect result.

* Added `PacingAssessmentTests.swift` — verifies all
  five cases exist and are constructible.

* Added `WordsPerMinuteTests.swift` — full boundary
  coverage for failable init and all five pacing
  assessment ranges. Lower and upper boundary tested
  per range — not single values inside the range.

* Added `TakeDurationTests.swift` — full boundary
  coverage for failable init and `isInRecommendedRange`.
  Boundaries tested at 59 (false), 60 (true), 90 (true).

* Added `FillerWordCountTests.swift` — coverage for
  negative rejection, zero acceptance, valid value
  acceptance.

## BDD scenarios covered

- Feature 2, Scenario 2: Recording stops automatically at 90 seconds
- Feature 3, Scenario 8: Filler words reduce the filler words dimension score
- Feature 3, Scenario 9: Ideal pacing produces maximum pacing score
- Feature 3, Scenario 10: Too fast pacing reduces pacing score

## Testing

- [x] All unit tests pass
- [x] App builds successfully
- [x] No infrastructure changes — unit tests only
- [ ] Integration tests run on device (not applicable — domain layer)

## Checklist

- [x] Domain layer has zero framework imports
- [x] No production code exists without a failing test
- [x] Sad path tests written before happy path
- [x] Test names use domain language in @Test description
- [x] Boundaries tested — not single values inside ranges
- [x] Commit history follows red → green → refactor convention
- [x] Issue linked and acceptance criteria met

## Notes

`WordsPerMinute` uses `Int` — same reasoning as `TakeDuration`.
WPM is always a whole number in practice. No floating
point complexity needed.

`PacingAssessment` ranges were defined as a domain
decision before any test was written:
tooSlow (1–99) · slightlyBelowIdeal (100–129) ·
ideal (130–160) · slightlyAboveIdeal (161–180) ·
tooFast (181–300). These ranges reflect realistic
interview speech patterns — not arbitrary boundaries.

`preconditionFailure` chosen over `default: return .tooSlow`
in `WordsPerMinute.pacingAssessment` — the failable init
guarantees 1–300 so any default hit signals a programming
error. Silent wrong behavior is worse than a crash in debug.

`isIdeal` computed property was considered and rejected
for `WordsPerMinute` — `pacingAssessment == .ideal`
is equivalent and adds no domain value. One source of
truth for pacing categorization.

Follow-up: `WordsPerMinute` and `FillerWordCount` are
consumed by `RulesBasedNLPScorer` in ticket #15.
`TakeDuration` is produced by `StopRecordingUseCase`
in ticket #9.